### PR TITLE
Add installation/usage docs and fix install scripts to restart FPPD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # fpp-VideoCapture
-Video Capture plugin for FPP
+
+Video Capture plugin for [Falcon Player (FPP)](https://github.com/FalconChristmas/fpp). Captures video from local cameras (USB webcams, Raspberry Pi camera modules) or IP network cameras and displays the feed on pixel overlay models (LED matrices).
+
+## Features
+
+- **V4L2 Capture** — USB webcams and other Video4Linux2 devices on Linux
+- **libcamera Capture** — Raspberry Pi camera modules (Pi Camera, HQ Camera, etc.)
+- **IP Video Capture** — Network/IP cameras via RTSP/HTTP streams (e.g. `rtsp://...`, `http://...`)
+
+## Installation
+
+### Via FPP Plugin Manager
+
+1. Navigate to **Content Setup → Plugins** in the FPP web UI.
+2. Locate **Video Capture** in the list of available plugins and click **Install**.
+3. Restart FPPD.
+
+## Usage
+
+1. Create a pixel overlay model in **Input/Output Setup → Pixel Overlay Models** matching your LED matrix layout. This is typically created automatically by xLights.
+2. Trigger a **Video Capture** or **IP Video Capture** effect from a playlist.
+
+### Via Playlist
+
+1. Go to **Content Setup → Playlists** and create or edit a playlist.
+2. Add a new entry, set **Type** to **Command**.
+3. Set **Command** to `Pixel Overlay → Overlay Model Effect`.
+4. Three fields appear:
+   - **Models** — select your pixel overlay model
+   - **Auto Enable/Disable** — keep `Enabled`
+   - **Effect** — select `Video Capture` or `IP Video Capture`
+5. When you select the effect, additional fields appear:
+
+   **For Video Capture:**
+   - **Camera** — enter the device path (e.g. `/dev/video0`) or `--Default--`
+
+   **For IP Video Capture:**
+   - **URL** — enter the stream URL (e.g. `rtsp://192.168.1.100:554/stream`)
+
+6. Save the playlist and play it.
+
+### Stopping an Effect
+
+Add another Command entry with `Overlay Model Effect`, select `Stop Effects` as the Effect, and play it.
+
+Or from **Status/Control → Effects** — running overlay effects appear under "Overlay Model Effects" with a Stop button.
+
+## License
+
+See [LICENSE](LICENSE).

--- a/scripts/fpp_install.sh
+++ b/scripts/fpp_install.sh
@@ -9,3 +9,7 @@ BASEDIR=$(dirname $0)
 cd $BASEDIR
 cd ..
 make
+
+: "${FPPDIR:=/opt/fpp}"
+. "${FPPDIR}/scripts/common"
+setSetting restartFlag 1

--- a/scripts/fpp_uninstall.sh
+++ b/scripts/fpp_uninstall.sh
@@ -8,3 +8,7 @@ cd $BASEDIR
 cd ..
 make clean
 
+: "${FPPDIR:=/opt/fpp}"
+. "${FPPDIR}/scripts/common"
+setSetting restartFlag 1
+


### PR DESCRIPTION
# Add installation/usage docs and fix install scripts to restart FPPD

## Summary

Update README.md with installation and usage instructions, and fix install/uninstall scripts to flag FPPD for restart.

## Changes

### README.md
- Replaced bare 2-line README with full documentation covering:
  - **Features** — V4L2, libcamera, and IP Video Capture backends
  - **Installation** — via FPP Plugin Manager
  - **Usage** — step-by-step Playlist setup instructions explaining how to add the "Overlay Model Effect" command and select the Video Capture or IP Video Capture effect, with dynamic argument fields (Camera device / URL)

### scripts/fpp_install.sh
- Added `setSetting restartFlag 1` at the end of the install script to signal FPP to restart FPPD after installation, ensuring the new effects are registered

### scripts/fpp_uninstall.sh
- Added `setSetting restartFlag 1` at the end of the uninstall script to signal FPP to restart FPPD after removal, ensuring effects are cleaned up

## Additional Comments

This PR provides install and usage instructions which closes #1.